### PR TITLE
Fix signup bug: validate password and confirm password before creating account

### DIFF
--- a/server/controller/auth.js
+++ b/server/controller/auth.js
@@ -38,6 +38,16 @@ class Auth {
       };
       return res.json({ error });
     }
+
+    // Check if password and confirm password are the same
+    if (password !== cPassword) {
+      error = {
+        ...error,
+        cPassword: "Passwords do not match"
+      };
+      return res.json({ error });
+    }
+
     if (name.length < 3 || name.length > 25) {
       error = { ...error, name: "Name must be 3-25 charecter" };
       return res.json({ error });


### PR DESCRIPTION
While testing the signup functionality, I found a bug where users could create an account even when the values in the **Password** and **Confirm Password (cPassword)** fields were different.

This issue has now been fixed. Users can successfully sign up only when both passwords match.
